### PR TITLE
refactor: change repositories to follow pattern properly

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,41 +1,41 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
-    -   id: check-ast
-    -   id: check-builtin-literals
-    -   id: debug-statements
-    -   id: end-of-file-fixer
-    -   id: requirements-txt-fixer
-    -   id: trailing-whitespace
--   repo: https://github.com/psf/black
+      - id: check-ast
+      - id: check-builtin-literals
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
     rev: 23.7.0
     hooks:
-    -   id: black
--   repo: https://github.com/asottile/pyupgrade
+      - id: black
+  - repo: https://github.com/asottile/pyupgrade
     rev: v3.10.1
     hooks:
-    -   id: pyupgrade
-        args: [--py37-plus, --keep-runtime-typing]
--   repo: https://github.com/asottile/reorder-python-imports
+      - id: pyupgrade
+        args: [--py310-plus, --keep-runtime-typing]
+  - repo: https://github.com/asottile/reorder-python-imports
     rev: v3.10.0
     hooks:
-    -   id: reorder-python-imports
-        args: [--py37-plus, --add-import, 'from __future__ import annotations']
--   repo: https://github.com/asottile/add-trailing-comma
-    rev: v3.0.1
+      - id: reorder-python-imports
+        args: [--py310-plus, --add-import, "from __future__ import annotations"]
+  - repo: https://github.com/asottile/add-trailing-comma
+    rev: v3.1.0
     hooks:
-    -   id: add-trailing-comma
--   repo: https://github.com/asottile/blacken-docs
+      - id: add-trailing-comma
+  - repo: https://github.com/asottile/blacken-docs
     rev: 1.16.0
     hooks:
-    -   id: blacken-docs
--   repo: https://github.com/hadialqattan/pycln
+      - id: blacken-docs
+  - repo: https://github.com/hadialqattan/pycln
     rev: v2.2.2
     hooks:
-    -   id: pycln
+      - id: pycln
 
 default_language_version:
-    python: python3.10
+  python: python3.10

--- a/src/classes/bot.py
+++ b/src/classes/bot.py
@@ -45,7 +45,7 @@ from tasks import LOAD_EXTENSIONS as TASKS_LOAD
 
 if TYPE_CHECKING:
     from typing import Any
-    from typing import Callable
+    from collections.abc import Callable
 
 
 MODULE_FOLDERS = ["listeners", "cogs", "tasks"]

--- a/src/cogs/premium.py
+++ b/src/cogs/premium.py
@@ -47,7 +47,10 @@ class Premium(MetadataGroupCog, name="premium"):
                 guild = await self.bot.fetch_guild(guild)
             except Exception:
                 # This could also be handled by removing the guild from the database, not in here though.
-                await self.bot.guild_settings_service.remove_premium_booster(guild.id)
+                await self.bot.guild_settings_service.set_premium_booster(
+                    guild.id,
+                    None,
+                )
                 continue
 
             guilds.append(guild)
@@ -117,8 +120,9 @@ class Premium(MetadataGroupCog, name="premium"):
             )
             return
 
-        await self.bot.guild_settings_service.remove_premium_booster(
+        await self.bot.guild_settings_service.set_premium_booster(
             interaction.guild.id,
+            None,
         )
         await interaction.response.send_message(
             "You are no longer boosting this server.",

--- a/src/common/osudaily.py
+++ b/src/common/osudaily.py
@@ -4,8 +4,8 @@
 from __future__ import annotations
 
 import functools
+from collections.abc import Callable
 from typing import Any
-from typing import Callable
 
 import orjson
 from aiohttp import ClientSession

--- a/src/common/premium.py
+++ b/src/common/premium.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from contextlib import suppress
-from typing import Callable
 
 import discord
 from discord import app_commands

--- a/src/listeners/errorhandler.py
+++ b/src/listeners/errorhandler.py
@@ -19,7 +19,7 @@ from discord.ext import commands
 
 if TYPE_CHECKING:
     from classes.bot import Sunny
-    from typing import Callable
+    from collections.abc import Callable
 
 
 def create_sentry_scope_ctx(ctx: commands.Context) -> sentry_sdk.Scope:

--- a/src/models/config.py
+++ b/src/models/config.py
@@ -3,8 +3,6 @@
 ###
 from __future__ import annotations
 
-from typing import List
-
 import orjson
 from aiosu.models import FrozenModel
 from common.logging import logger
@@ -34,7 +32,7 @@ class LavalinkConfig(FrozenModel):
 class LavalinkConfigList(FrozenModel):
     spotify_client_id: str = ""
     spotify_client_secret: str = ""
-    nodes: List[LavalinkConfig] = Field(default_factory=lambda: [LavalinkConfig()])
+    nodes: list[LavalinkConfig] = Field(default_factory=lambda: [LavalinkConfig()])
 
 
 class OsuAPIConfig(FrozenModel):
@@ -63,8 +61,8 @@ class Config(FrozenModel):
     sentry: str = ""
     support_invite: str = "https://discord.gg/ufHV3T3UPD"
     premium: PremiumConfig = Field(default_factory=PremiumConfig)
-    owners: List[int] = Field(default_factory=lambda: [151670779782758400])
-    command_prefixes: List[str] = Field(default_factory=lambda: ["s."])
+    owners: list[int] = Field(default_factory=lambda: [151670779782758400])
+    command_prefixes: list[str] = Field(default_factory=lambda: ["s."])
     redis: RedisConfig = Field(default_factory=RedisConfig)
     mongo: MongoConfig = Field(default_factory=MongoConfig)
     lavalink: LavalinkConfigList = Field(default_factory=LavalinkConfigList)
@@ -72,7 +70,7 @@ class Config(FrozenModel):
 
 class ConfigList(FrozenModel):
     select: int = 0
-    configs: List[Config] = Field(default_factory=lambda: [Config()])
+    configs: list[Config] = Field(default_factory=lambda: [Config()])
 
     def __get_selected_config(self) -> Config:
         return self.configs[self.select]

--- a/src/models/user_preferences.py
+++ b/src/models/user_preferences.py
@@ -4,13 +4,14 @@
 from __future__ import annotations
 
 from aiordr.models import RenderOptions
+from models.weather import Units
 from pydantic import BaseModel
 
 
 class UserPreferences(BaseModel):
     discord_id: int
     lazer: bool = False
-    units: str = "metric"
+    units: Units
 
 
 class RecordingPreferences(RenderOptions):

--- a/src/repository/beatmap.py
+++ b/src/repository/beatmap.py
@@ -3,7 +3,6 @@
 ###
 from __future__ import annotations
 
-from aiosu.models import Beatmap
 from redis.asyncio import Redis
 
 
@@ -15,52 +14,46 @@ class BeatmapRepository:
     def __init__(self, redis: Redis):
         self.redis = redis
 
-    async def get_one(self, channel_id: int) -> Beatmap:
+    async def get_one(self, channel_id: int) -> str | None:
         """Get beatmap from database.
 
         Args:
             channel_id (int): Channel ID.
-        Raises:
-            ValueError: Beatmap not found.
         Returns:
-            Beatmap: Beatmap data.
+            Optional[str]: Beatmap data.
         """
-        beatmap = await self.redis.get(f"sunny:{channel_id}:beatmap")
-        if beatmap is None:
-            raise ValueError("Beatmap not found.")
-        return Beatmap.model_validate_json(beatmap)
+        return await self.redis.get(f"sunny:{channel_id}:beatmap")
 
-    async def get_many(self) -> list[Beatmap]:
+    async def get_many(self) -> list[str]:
         """Get all beatmaps from database.
 
         Returns:
-            list[Beatmap]: List of beatmaps.
+            list[Any]: List of beatmap data.
         """
-        beatmaps = await self.redis.keys("sunny:*:beatmap")
-        return [Beatmap.model_validate_json(beatmap) for beatmap in beatmaps]
+        return await self.redis.keys("sunny:*:beatmap")
 
-    async def add(self, channel_id: int, beatmap: Beatmap) -> None:
+    async def add(self, channel_id: int, beatmap: str) -> None:
         """Add new beatmap to database.
 
         Args:
             channel_id (int): Channel ID.
-            beatmap (Beatmap): Beatmap data.
+            beatmap (str): Beatmap JSON data.
         """
         await self.redis.set(
             f"sunny:{channel_id}:beatmap",
-            beatmap.model_dump_json(),
+            beatmap,
         )
 
-    async def update(self, channel_id: int, beatmap: Beatmap) -> None:
+    async def update(self, channel_id: int, beatmap: str) -> None:
         """Update beatmap data.
 
         Args:
             channel_id (int): Channel ID.
-            beatmap (Beatmap): Beatmap data.
+            beatmap (str): Beatmap JSON data.
         """
         await self.redis.set(
             f"sunny:{channel_id}:beatmap",
-            beatmap.model_dump_json(),
+            beatmap,
         )
 
     async def delete(self, channel_id: int) -> None:

--- a/src/repository/stats.py
+++ b/src/repository/stats.py
@@ -3,9 +3,6 @@
 ###
 from __future__ import annotations
 
-from typing import Any
-
-import orjson
 from redis.asyncio import Redis
 
 
@@ -45,12 +42,12 @@ class StatsRepository:
         """
         await self.redis.set("sunny:user-count", count)
 
-    async def set_commands(self, commands: dict[str, Any]) -> None:
+    async def set_commands(self, commands_data: bytes) -> None:
         """Set commands.
         Args:
-            commands (dict): Commands.
+            commands_data (bytes): Commands JSON data.
         """
-        await self.redis.set("sunny:commands", orjson.dumps(commands))
+        await self.redis.set("sunny:commands", commands_data)
 
     async def set_bot_version(self, version: str) -> None:
         """Set bot version.

--- a/src/service/beatmap.py
+++ b/src/service/beatmap.py
@@ -24,14 +24,18 @@ class BeatmapService:
         Returns:
             Beatmap: Beatmap data.
         """
-        return await self.repository.get_one(channel_id)
+        data = await self.repository.get_one(channel_id)
+        if data is None:
+            raise ValueError("Beatmap not found.")
+        return Beatmap.model_validate_json(data)
 
     async def get_many(self) -> list[Beatmap]:
         """Get all beatmaps from database.
         Returns:
             list[Beatmap]: List of beatmaps.
         """
-        return await self.repository.get_many()
+        data = await self.repository.get_many()
+        return [Beatmap.model_validate_json(beatmap) for beatmap in data]
 
     async def add(self, channel_id: int, beatmap: Beatmap) -> None:
         """Add new beatmap to database.
@@ -39,7 +43,8 @@ class BeatmapService:
             channel_id (int): Channel ID.
             beatmap (Beatmap): Beatmap data.
         """
-        await self.repository.add(channel_id, beatmap)
+        data = beatmap.model_dump_json()
+        await self.repository.add(channel_id, data)
 
     async def update(self, channel_id: int, beatmap: Beatmap) -> None:
         """Update beatmap data.
@@ -47,7 +52,8 @@ class BeatmapService:
             channel_id (int): Channel ID.
             beatmap (Beatmap): Beatmap data.
         """
-        await self.repository.update(channel_id, beatmap)
+        data = beatmap.model_dump_json()
+        await self.repository.update(channel_id, data)
 
     async def delete(self, channel_id: int) -> None:
         """Delete beatmap data.

--- a/src/service/beatmapset.py
+++ b/src/service/beatmapset.py
@@ -28,7 +28,10 @@ class BeatmapsetService:
         Returns:
             Beatmapset: Beatmapset data.
         """
-        return await self.repository.get_one(beatmapset_id)
+        data = await self.repository.get_one(beatmapset_id)
+        if data is None:
+            raise ValueError("Beatmapset not found.")
+        return Beatmapset.model_validate(data)
 
     async def get_many(self) -> list[Beatmapset]:
         """Get all beatmapsets from database.
@@ -36,7 +39,8 @@ class BeatmapsetService:
         Returns:
             list[Beatmapset]: List of beatmapsets.
         """
-        return await self.repository.get_many()
+        data = await self.repository.get_many()
+        return [Beatmapset.model_validate(beatmapset) for beatmapset in data]
 
     async def get_random(self, gamemode: Gamemode) -> Beatmapset:
         """Get random beatmapset from database.
@@ -47,4 +51,5 @@ class BeatmapsetService:
         Returns:
             Beatmapset: Beatmapset data.
         """
-        return await self.repository.get_random(gamemode)
+        data = await self.repository.get_random(gamemode.name_api)
+        return Beatmapset.model_validate(data[0])

--- a/src/service/graph.py
+++ b/src/service/graph.py
@@ -29,7 +29,10 @@ class GraphService:
         Returns:
             BytesIO: Graph.
         """
-        return await self.repository.get_one(osu_id, mode_id, lazer)
+        data = await self.repository.get_one(osu_id, mode_id, lazer)
+        if data is None:
+            raise ValueError("Graph not found.")
+        return data
 
     async def get_many(self, lazer: bool = False) -> list[BytesIO]:
         """Get all graphs from Redis.
@@ -40,7 +43,8 @@ class GraphService:
         Returns:
             list[BytesIO]: List of graphs.
         """
-        return await self.repository.get_many(lazer)
+        data = await self.repository.get_many(lazer)
+        return [BytesIO(graph) for graph in data]
 
     async def add(
         self,
@@ -56,7 +60,7 @@ class GraphService:
             graph (BytesIO): Graph.
             lazer (bool, optional): Lazer graph. Defaults to False.
         """
-        await self.repository.add(osu_id, graph, mode_id, lazer)
+        await self.repository.add(osu_id, graph.getvalue(), mode_id, lazer)
 
     async def delete(self, osu_id: int, mode_id: int, lazer: bool = False) -> None:
         """Delete graph from Redis.

--- a/src/service/guild_settings.py
+++ b/src/service/guild_settings.py
@@ -96,7 +96,7 @@ class GuildSettingsService:
             GuildSettings: Guild settings.
         """
         guild_settings = await self.get_safe(guild_id)
-        await self.update(guild_id, guild_settings)
+        await self.update(guild_settings)
         return guild_settings
 
     async def update(self, guild_settings: GuildSettings) -> None:

--- a/src/service/guild_settings.py
+++ b/src/service/guild_settings.py
@@ -27,7 +27,10 @@ class GuildSettingsService:
         Returns:
             GuildSettings: Guild settings.
         """
-        return await self.repository.get_one(guild_id)
+        data = await self.repository.get_one(guild_id=guild_id)
+        if data is None:
+            raise ValueError("Settings not found.")
+        return GuildSettings.model_validate(data)
 
     async def get_safe(self, guild_id: int) -> GuildSettings:
         """Get guild settings from database.
@@ -39,17 +42,41 @@ class GuildSettingsService:
             GuildSettings: Guild settings.
         """
         try:
-            return await self.repository.get_one(guild_id)
+            return await self.get_one(guild_id)
         except ValueError:
             return GuildSettings(guild_id=guild_id)
 
-    async def get_many(self) -> list[GuildSettings]:
-        """Get all guild settings from database.
+    async def get_user_boosts(self, user_id: int) -> list[int]:
+        """Get all guilds boosted by user.
+
+        Args:
+            user_id (int): User ID.
 
         Returns:
-            list[GuildSettings]: List of guild settings.
+            list[int]: List of guild IDs.
         """
-        return await self.repository.get_many()
+        data = await self.repository.get_many(booster_id=user_id)
+        return [guild_setting["guild_id"] for guild_setting in data]
+
+    async def get_user_boosts_count(self, user_id: int) -> int:
+        """Get user boosts count.
+
+        Args:
+            user_id (int): User ID.
+
+        Returns:
+            int: Boosts count.
+        """
+        return await self.repository.count(booster_id=user_id)
+
+    async def get_all_boosted_guilds(self) -> list[int]:
+        """Get all guilds that are boosted.
+
+        Returns:
+            list[int]: List of guild IDs.
+        """
+        data = await self.repository.get_many(boosted=True)
+        return [guild_setting["guild_id"] for guild_setting in data]
 
     async def add(self, guild_settings: GuildSettings) -> None:
         """Add new guild settings to database.
@@ -57,7 +84,20 @@ class GuildSettingsService:
         Args:
             guild_settings (GuildSettings): Guild settings.
         """
-        await self.repository.add(guild_settings)
+        await self.repository.add(guild_settings.model_dump())
+
+    async def create(self, guild_id: int) -> GuildSettings:
+        """Create default guild settings.
+
+        Args:
+            guild_id (int): Guild ID.
+
+        Returns:
+            GuildSettings: Guild settings.
+        """
+        guild_settings = await self.get_safe(guild_id)
+        await self.update(guild_id, guild_settings)
+        return guild_settings
 
     async def update(self, guild_settings: GuildSettings) -> None:
         """Update guild settings.
@@ -65,7 +105,10 @@ class GuildSettingsService:
         Args:
             guild_settings (GuildSettings): Guild settings.
         """
-        await self.repository.update(guild_settings)
+        await self.repository.update(
+            guild_settings.guild_id,
+            guild_settings.model_dump(exclude={"guild_id"}),
+        )
 
     async def delete(self, guild_id: int) -> None:
         """Delete guild settings.
@@ -74,19 +117,6 @@ class GuildSettingsService:
             guild_id (int): Guild ID.
         """
         await self.repository.delete(guild_id)
-
-    async def create(self, guild_id: int) -> GuildSettings:
-        """Create default settings for guild.
-
-        Args:
-            guild_id (int): Guild ID.
-
-        Returns:
-            GuildSettings: Guild settings.
-        """
-        settings = GuildSettings(guild_id=guild_id)
-        await self.add(settings)
-        return settings
 
     async def get_prefix(self, guild_id: int) -> str:
         """Get guild prefix.
@@ -107,11 +137,7 @@ class GuildSettingsService:
             guild_id (int): Guild ID.
             prefix (str): Guild prefix.
         """
-        try:
-            settings = await self.get_one(guild_id)
-        except ValueError:
-            settings = await self.create(guild_id)
-
+        settings = await self.get_safe(guild_id)
         settings.prefix = prefix
         await self.update(settings)
 
@@ -150,11 +176,7 @@ class GuildSettingsService:
         Returns:
             bool: Listener status.
         """
-        try:
-            settings = await self.get_one(guild_id)
-        except ValueError:
-            settings = await self.create(guild_id)
-
+        settings = await self.get_safe(guild_id)
         settings.use_listeners = not settings.use_listeners
         await self.update(settings)
         return settings.use_listeners
@@ -180,11 +202,7 @@ class GuildSettingsService:
         Returns:
             bool: Auto disconnect status.
         """
-        try:
-            settings = await self.get_one(guild_id)
-        except ValueError:
-            settings = await self.create(guild_id)
-
+        settings = await self.get_safe(guild_id)
         settings.voice_auto_disconnect = not settings.voice_auto_disconnect
         await self.update(settings)
         return settings.voice_auto_disconnect
@@ -196,11 +214,7 @@ class GuildSettingsService:
             guild_id (int): Guild ID.
             role_id (int): Role ID.
         """
-        try:
-            settings = await self.get_one(guild_id)
-        except ValueError:
-            settings = await self.create(guild_id)
-
+        settings = await self.get_safe(guild_id)
         settings.dj_role = role_id
         await self.update(settings)
 
@@ -216,61 +230,17 @@ class GuildSettingsService:
         settings = await self.get_safe(guild_id)
         return settings.booster
 
-    async def set_premium_booster(self, guild_id: int, booster_id: int) -> None:
+    async def set_premium_booster(
+        self,
+        guild_id: int,
+        booster_id: int | None,
+    ) -> None:
         """Set premium booster.
 
         Args:
             guild_id (int): Guild ID.
             booster_id (int): Booster ID.
         """
-        try:
-            settings = await self.get_one(guild_id)
-        except ValueError:
-            settings = await self.create(guild_id)
-
+        settings = await self.get_safe(guild_id)
         settings.booster = booster_id
         await self.update(settings)
-
-    async def remove_premium_booster(self, guild_id: int) -> None:
-        """Remove premium booster.
-
-        Args:
-            guild_id (int): Guild ID.
-        """
-        try:
-            settings = await self.get_one(guild_id)
-        except ValueError:
-            return
-
-        settings.booster = None
-        await self.update(settings)
-
-    async def get_user_boosts(self, user_id: int) -> list[int]:
-        """Get all guilds boosted by user.
-
-        Args:
-            user_id (int): User ID.
-
-        Returns:
-            list[int]: List of guild IDs.
-        """
-        return await self.repository.get_user_boosts(user_id)
-
-    async def get_user_boosts_count(self, user_id: int) -> int:
-        """Get user boosts count.
-
-        Args:
-            user_id (int): User ID.
-
-        Returns:
-            int: Boosts count.
-        """
-        return await self.repository.get_user_boosts_count(user_id)
-
-    async def get_all_boosted_guilds(self) -> list[int]:
-        """Get all guilds that are boosted.
-
-        Returns:
-            list[int]: List of guild IDs.
-        """
-        return await self.repository.get_all_boosted_guilds()

--- a/src/service/stats.py
+++ b/src/service/stats.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import orjson
 from repository import StatsRepository
 
 
@@ -49,7 +50,7 @@ class StatsService:
         Args:
             commands (dict): Commands.
         """
-        await self.repository.set_commands(commands)
+        await self.repository.set_commands(orjson.dumps(commands))
 
     async def set_bot_version(self, version: str) -> None:
         """Set bot version.

--- a/src/service/user.py
+++ b/src/service/user.py
@@ -3,8 +3,6 @@
 ###
 from __future__ import annotations
 
-from contextlib import suppress
-
 from models.user import DatabaseUser
 from repository.user import UserRepository
 
@@ -26,28 +24,47 @@ class UserService:
         Returns:
             DatabaseUser: User data.
         """
-        return await self.repository.get_one(user_id)
+        data = await self.repository.get_one(user_id)
+        if data is None:
+            raise ValueError("User not found.")
+        return DatabaseUser.model_validate(data)
+
+    async def get_safe(self, user_id: int) -> DatabaseUser:
+        """Get user data from database.
+        Args:
+            user_id (int): User ID.
+        Returns:
+            DatabaseUser: User data.
+        """
+        try:
+            return await self.get_one(user_id)
+        except ValueError:
+            return DatabaseUser(discord_id=user_id)
 
     async def get_many(self) -> list[DatabaseUser]:
         """Get all users from database.
         Returns:
             list[DatabaseUser]: List of users.
         """
-        return await self.repository.get_many()
+        data = await self.repository.get_many()
+        return [DatabaseUser.model_validate(user) for user in data]
 
     async def add(self, user: DatabaseUser) -> None:
         """Add new user to database.
         Args:
             user (DatabaseUser): User data.
         """
-        await self.repository.add(user)
+        await self.repository.add(user.model_dump())
 
     async def update(self, user: DatabaseUser) -> None:
         """Update user data.
         Args:
             user (DatabaseUser): User data.
         """
-        await self.repository.update(user)
+        await self.repository.update(
+            user.discord_id,
+            user.model_dump(exclude={"discord_id"}),
+        )
 
     async def delete(self, user_id: int) -> None:
         """Delete user data.
@@ -61,23 +78,18 @@ class UserService:
         Args:
             user_id (int): User ID.
         """
-        try:
-            user = await self.get_one(user_id)
-            user.blacklist = True
-            await self.update(user)
-        except ValueError:
-            user = DatabaseUser(discord_id=user_id, blacklist=True)
-            await self.add(user)
+        user = await self.get_safe(user_id)
+        user.blacklist = True
+        await self.update(user)
 
     async def unblacklist(self, user_id: int) -> None:
         """Unblacklist user.
         Args:
             user_id (int): User ID.
         """
-        with suppress(ValueError):
-            user = await self.get_one(user_id)
-            user.blacklist = False
-            await self.update(user)
+        user = await self.get_safe(user_id)
+        user.blacklist = False
+        await self.update(user)
 
     async def is_blacklisted(self, user_id: int) -> bool:
         """Check if user is blacklisted.
@@ -86,8 +98,5 @@ class UserService:
         Returns:
             bool: True if user is blacklisted.
         """
-        try:
-            user = await self.get_one(user_id)
-            return user.blacklist
-        except ValueError:
-            return False
+        user = await self.get_safe(user_id)
+        return user.blacklist

--- a/src/tasks/cron.py
+++ b/src/tasks/cron.py
@@ -35,7 +35,10 @@ class CronTask(MetadataCog, hidden=True):
             )
             is_premium = await check_premium(booster_id, self.bot)
             if not is_premium:
-                await self.bot.guild_settings_service.remove_premium_booster(guild_id)
+                await self.bot.guild_settings_service.set_premium_booster(
+                    guild_id,
+                    None,
+                )
                 logger.info(
                     f"Removed premium from guild {guild_id} due to expiration on booster {booster_id}",
                 )


### PR DESCRIPTION
Changed repositories to only return basic data and services to return the actual python models.

Also removed a couple repository functions and wrote more generic ones instead in order to remove logic from repository layer.