### PR TITLE
fix: suppress potential `AttributeError`

### DIFF
--- a/src/classes/bot.py
+++ b/src/classes/bot.py
@@ -3,6 +3,7 @@
 ###
 from __future__ import annotations
 
+from contextlib import suppress
 from functools import partial
 from typing import TYPE_CHECKING
 
@@ -331,5 +332,6 @@ class Sunny(commands.AutoShardedBot):
         await self.stable_storage.close()
         await self.lazer_storage.close()
         await self.ordr_client.close()
-        await self.aiohttp_session.close()
+        with suppress(AttributeError):
+            await self.aiohttp_session.close()
         await super().close()


### PR DESCRIPTION
Spotted in https://sunnycord.sentry.io/issues/4447016402/events/0c6dd68bc29741a6ac55e81683c72340/

Can potentially happen when shutting down before `setup_hook()` was ran. Would have not affected anyway, so suppressing the error works.